### PR TITLE
build for arm , update readme

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,6 @@ jobs:
         go-version: 1.16
 
     - name: Build
-      run: go build
+      run: ./build.sh
 
-    # - name: Test
-    #   run: go test -v ./...
+    

--- a/README.md
+++ b/README.md
@@ -1,9 +1,85 @@
-## Prometheus exporter for mosquitto mqtt broker
+## Prometheus exporter for Mosquitto mqtt broker
 
-A Mosquitto Mqtt Broker metric exporter for Prometheus 
+<!-- A Mosquitto Mqtt Broker metric exporter for Prometheus  -->
+
+## Flags
+
+  - `brokerAddress` (required) - mqtt broker ip / url and port (default "127.0.0.1:1883")
+  - `listenPort`    (optional) - exporter listening address (default "9992")
+  - `password`      (optional) - mqtt password username
+  - `username`      (optional) - mqtt broker username
+
+## Run exporter 
+
+```bash
+./mosquitto_exporter-linux-amd64 --brokerAddress=localhost:1883`
+```
+
+## Metrics
+
+|Mosquitto Topic|Prometheus Metric|Description|
+|----------------|-----------------|-----------|
+$SYS/broker/uptime |mosquitto_uptime| mosquitto broker uptime
+$SYS/broker/messages/sent|mosquitto_messages_sent|mosquitto broker messages sent
+$SYS/broker/messages/received|mosquitto_messages_received|mosquitto broker messages received
+$SYS/broker/clients/total|mosquitto_clients_total|The total number of active and inactive clients currently connected and registered on the broker.
+$SYS/broker/clients/maximum|mosquitto_clients_maximum|The maximum number of clients that have been connected to the broker at the same time.
+$SYS/broker/clients/active|mosquitto_clients_active|The number of currently connected clients.
+$SYS/broker/bytes/sent|mosquitto_bytes_sent|The total number of bytes sent since the broker started.
+$SYS/broker/bytes/received|mosquitto_bytes_received|The total number of bytes received since the broker started.
+$SYS/broker/heap/current|mosquitto_heap_current|The current size of the heap memory in use by mosquitto. Note that this topic may be unavailable depending on compile time options.
+$SYS/broker/heap/maximum|mosquitto_heap_maximum|The largest amount of heap memory used by mosquitto. Note that this topic may be unavailable depending on compile time options.
 
 
+metrics example
 
+```
+# HELP mosquitto_mqtt_mosquitto_bytes_received The total number of bytes received since the broker started.
+# TYPE mosquitto_mqtt_mosquitto_bytes_received gauge
+mosquitto_mqtt_mosquitto_bytes_received 0
+# HELP mosquitto_mqtt_mosquitto_bytes_sent The total number of bytes sent since the broker started.
+# TYPE mosquitto_mqtt_mosquitto_bytes_sent gauge
+mosquitto_mqtt_mosquitto_bytes_sent 0
+# HELP mosquitto_mqtt_mosquitto_clients_active The number of currently connected clients.
+# TYPE mosquitto_mqtt_mosquitto_clients_active gauge
+mosquitto_mqtt_mosquitto_clients_active 0
+# HELP mosquitto_mqtt_mosquitto_clients_maximum The maximum number of clients that have been connected to the broker at the same time.
+# TYPE mosquitto_mqtt_mosquitto_clients_maximum gauge
+mosquitto_mqtt_mosquitto_clients_maximum 0
+# HELP mosquitto_mqtt_mosquitto_clients_total The total number of active and inactive clients currently connected and registered on the broker.
+# TYPE mosquitto_mqtt_mosquitto_clients_total gauge
+mosquitto_mqtt_mosquitto_clients_total 0
+# HELP mosquitto_mqtt_mosquitto_heap_current The current size of the heap memory in use by mosquitto. Note that this topic may be unavailable depending on compile time options.
+# TYPE mosquitto_mqtt_mosquitto_heap_current gauge
+mosquitto_mqtt_mosquitto_heap_current 0
+# HELP mosquitto_mqtt_mosquitto_heap_maximum The largest amount of heap memory used by mosquitto. Note that this topic may be unavailable depending on compile time options.
+# TYPE mosquitto_mqtt_mosquitto_heap_maximum gauge
+mosquitto_mqtt_mosquitto_heap_maximum 0
+# HELP mosquitto_mqtt_mosquitto_messages_received mosquitto broker messages received
+# TYPE mosquitto_mqtt_mosquitto_messages_received gauge
+mosquitto_mqtt_mosquitto_messages_received 0
+# HELP mosquitto_mqtt_mosquitto_messages_sent mosquitto broker messages sent
+# TYPE mosquitto_mqtt_mosquitto_messages_sent gauge
+mosquitto_mqtt_mosquitto_messages_sent 0
+# HELP mosquitto_mqtt_mosquitto_uptime mosquitto broker uptime
+# TYPE mosquitto_mqtt_mosquitto_uptime gauge
+mosquitto_mqtt_mosquitto_uptime 5973
+```
+
+## Build exporter 
+
+This command will build for 
+
+1. linux/386 
+2. linux/amd64
+3. linux/arm64" 
+4. linux/armv7
+4. linux/armv6
+4. linux/armv5
+
+```bash
+./build.sh
+```
 
 <!-- zap logging
 channals for mqtt

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+platforms=("linux/386" "linux/amd64" "linux/arm64" )
+
+for platform in "${platforms[@]}"
+do
+    platform_split=(${platform//\// })
+    GOOS=${platform_split[0]}
+    GOARCH=${platform_split[1]}
+
+    BinaryName="mosquitto_exporter-${GOOS}-${GOARCH}"
+    echo $BinaryName
+
+    env GOOS=$GOOS GOARCH=$GOARCH go build -ldflags="-X 'main.version=v0.0.1'" -o $BinaryName
+
+done
+
+
+#arm build
+armversions=("5" "6" "7")
+
+for armversion in "${armversions[@]}"
+do
+    platform_split=(${platform//\// })
+    GOOS=linux
+    GOARCH=arm
+    GOARM=$armversion
+
+    BinaryName="mosquitto_exporter-${GOOS}-${GOARCH}v${armversion}"
+    echo $BinaryName
+
+    env GOOS=$GOOS GOARCH=$GOARCH GOARM=$GOARM go build -ldflags="-X 'main.version=v0.0.1'" -o $BinaryName
+
+done

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -28,17 +28,6 @@ var mosquittoBytesReceivedGauge = prometheus.NewGauge(prometheus.GaugeOpts{Name:
 var mosquittoHeapCurrentGauge = prometheus.NewGauge(prometheus.GaugeOpts{Name: "mosquitto_heap_current", Help: "The current size of the heap memory in use by mosquitto. Note that this topic may be unavailable depending on compile time options.", Namespace: namespace})
 var mosquittoHeapMaximumGauge = prometheus.NewGauge(prometheus.GaugeOpts{Name: "mosquitto_heap_maximum", Help: "The largest amount of heap memory used by mosquitto. Note that this topic may be unavailable depending on compile time options.", Namespace: namespace})
 
-// $SYS/broker/bytes/received
-
-// $SYS/broker/bytes/sent
-
-// $SYS/broker/heap/current size
-
-// $SYS/broker/heap/maximum size
-// var mosquittoClientsActive= prometheus.NewGauge(prometheus.GaugeOpts{Name: "mosquitto_messages_Active" , Help: "mosquitto broker active clients" , Namespace: namespace})
-
-// $SYS/broker/clients/total
-
 func init() {
 
 	prometheus.Unregister(collectors.NewGoCollector())

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 
 	"net/http"
@@ -11,9 +12,14 @@ import (
 	mqttcon "rizkyrajitha.github.io/mosquitto_exporter/mqttcon"
 )
 
-var brokerAddress, username, password, listenPort string
+var version, brokerAddress, username, password, listenPort string
 
 func main() {
+
+	flag.Usage = func() {
+		fmt.Printf("mosquitto_exporter %s\nA Mosquitto Mqtt Broker metric exporter for Prometheus\n\nOptions\n", version)
+        flag.PrintDefaults()
+	}
 
 	flag.StringVar(&brokerAddress, "brokerAddress", "127.0.0.1:1883", "mqtt broker ip / url and port")
 	flag.StringVar(&listenPort, "listenPort", "9992", "exporter listening address")


### PR DESCRIPTION
## Prometheus exporter for Mosquitto mqtt broker

Release v0.0.1

### supported metrics 

1. mosquitto_uptime
2. mosquitto_messages_sent
3. mosquitto_messages_received
4. mosquitto_clients_total
5. mosquitto_clients_maximum
6. mosquitto_clients_active
7. mosquitto_bytes_sent
8. mosquitto_bytes_received
9. mosquitto_heap_current
10. mosquitto_heap_maximum

### supported build platforms 

1. linux/386 
2. linux/amd64
3. linux/arm64" 
4. linux/armv7
4. linux/armv6
4. linux/armv5